### PR TITLE
Version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog], and this project adheres to
+[Semantic Versioning].
+
+# Unreleased
+
+None.
+
+# 0.2.0 (13. July 2022)
+
+- **changed:** Now using unbounded `crossbeam-channel` instead of bounded
+  `std::sync::mpsc` channel internally.
+- **changed:** Channel send errors in background database thread are now
+  ignored instead of panicking.
+
+# 0.1.0 (25. April 2022)
+
+- Initial release.
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rusqlite"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Programatik <programatik29@gmail.com>"]
 edition = "2021"
 description = "Asynchronous handle for rusqlite library."


### PR DESCRIPTION
- **changed:** Now using unbounded `crossbeam-channel` instead of bounded
  `std::sync::mpsc` channel internally.
- **changed:** Channel send errors in background database thread are now
  ignored instead of panicking.