### PR TITLE
Add `Connection::close` method to explicitly close a `Connection`

### DIFF
--- a/examples/in_memory.rs
+++ b/examples/in_memory.rs
@@ -55,5 +55,6 @@ async fn main() -> Result<()> {
         println!("Found person {:?}", person);
     }
 
+    conn.close().await.map_err(|e| e.1)?;
     Ok(())
 }

--- a/examples/multiple_tasks.rs
+++ b/examples/multiple_tasks.rs
@@ -58,6 +58,7 @@ async fn main() -> Result<()> {
         println!("Found person {:?}", person);
     }
 
+    conn.close().await.map_err(|e| e.1)?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR adds a new method meant for explicit connection closing. This method is an async equivalent to the `rusqlite` `Connection::close` method.

Closes #7.