### PR TITLE
Make `Connection::call` return a `Result`

### DIFF
--- a/examples/in_memory.rs
+++ b/examples/in_memory.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use rusqlite::{params, Result};
-use tokio_rusqlite::Connection;
+use rusqlite::params;
+use tokio_rusqlite::{Connection, Result};
 
 #[derive(Debug)]
 struct Person {
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
                         data: row.get(2)?,
                     })
                 })?
-                .collect::<Result<Vec<Person>, rusqlite::Error>>()?;
+                .collect::<std::result::Result<Vec<Person>, rusqlite::Error>>()?;
 
             Ok::<_, rusqlite::Error>(people)
         })
@@ -55,6 +55,6 @@ async fn main() -> Result<()> {
         println!("Found person {:?}", person);
     }
 
-    conn.close().await.map_err(|e| e.1)?;
+    conn.close().await?;
     Ok(())
 }

--- a/examples/multiple_tasks.rs
+++ b/examples/multiple_tasks.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use rusqlite::{params, Result};
+use rusqlite::params;
 use tokio::task::JoinHandle;
-use tokio_rusqlite::Connection;
+use tokio_rusqlite::{Connection, Result};
 
 #[derive(Debug)]
 struct Person {
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
                         data: row.get(2)?,
                     })
                 })?
-                .collect::<Result<Vec<Person>, rusqlite::Error>>()?;
+                .collect::<std::result::Result<Vec<Person>, rusqlite::Error>>()?;
 
             Ok::<_, rusqlite::Error>(people)
         })
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
         println!("Found person {:?}", person);
     }
 
-    conn.close().await.map_err(|e| e.1)?;
+    conn.close().await?;
     Ok(())
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,16 +1,16 @@
-use rusqlite::{ffi, Error, ErrorCode};
+use rusqlite::{ffi, ErrorCode};
 
-use crate::Connection;
+use crate::{Connection, Result};
 
 #[tokio::test]
-async fn open_in_memory_test() -> Result<(), rusqlite::Error> {
+async fn open_in_memory_test() -> Result<()> {
     let conn = Connection::open_in_memory().await;
     assert!(conn.is_ok());
     Ok(())
 }
 
 #[tokio::test]
-async fn call_success_test() -> Result<(), rusqlite::Error> {
+async fn call_success_test() -> Result<()> {
     let conn = Connection::open_in_memory().await?;
 
     let result = conn
@@ -22,35 +22,37 @@ async fn call_success_test() -> Result<(), rusqlite::Error> {
         })
         .await;
 
-    assert_eq!(Ok(0), result);
+    assert_eq!(0, result.unwrap());
 
     Ok(())
 }
 
 #[tokio::test]
-async fn call_failure_test() -> Result<(), rusqlite::Error> {
+async fn call_failure_test() -> Result<()> {
     let conn = Connection::open_in_memory().await?;
 
     let result = conn.call(|conn| conn.execute("Invalid sql", [])).await;
 
-    assert_eq!(
-        Err(Error::SqlInputError {
-            error: ffi::Error {
-                code: ErrorCode::Unknown,
-                extended_code: 1
-            },
-            msg: "near \"Invalid\": syntax error".to_string(),
-            sql: "Invalid sql".to_string(),
-            offset: 0
-        }),
-        result
-    );
+    assert!(match result.unwrap_err() {
+        crate::Error::Rusqlite(e) => {
+            e == rusqlite::Error::SqlInputError {
+                error: ffi::Error {
+                    code: ErrorCode::Unknown,
+                    extended_code: 1,
+                },
+                msg: "near \"Invalid\": syntax error".to_string(),
+                sql: "Invalid sql".to_string(),
+                offset: 0,
+            }
+        }
+        _ => false,
+    });
 
     Ok(())
 }
 
 #[tokio::test]
-async fn close_success_test() -> Result<(), rusqlite::Error> {
+async fn close_success_test() -> Result<()> {
     let conn = Connection::open_in_memory().await?;
 
     assert!(conn.close().await.is_ok());
@@ -59,7 +61,7 @@ async fn close_success_test() -> Result<(), rusqlite::Error> {
 }
 
 #[tokio::test]
-async fn double_close_test() -> Result<(), rusqlite::Error> {
+async fn double_close_test() -> Result<()> {
     let conn = Connection::open_in_memory().await?;
 
     let conn2 = conn.clone();
@@ -71,18 +73,25 @@ async fn double_close_test() -> Result<(), rusqlite::Error> {
 }
 
 #[tokio::test]
-#[should_panic]
-async fn close_call_test() {
-    let conn = Connection::open_in_memory().await.unwrap();
+async fn close_call_test() -> Result<()> {
+    let conn = Connection::open_in_memory().await?;
 
     let conn2 = conn.clone();
 
     assert!(conn.close().await.is_ok());
-    conn2.call(|conn| conn.execute("SELECT 1;", [])).await.unwrap();
+
+    let result = conn2.call(|conn| conn.execute("SELECT 1;", [])).await;
+
+    assert!(matches!(
+        result.unwrap_err(),
+        crate::Error::ConnectionClosed
+    ));
+
+    Ok(())
 }
 
 #[tokio::test]
-async fn close_failure_test() -> Result<(), rusqlite::Error> {
+async fn close_failure_test() -> Result<()> {
     let conn = Connection::open_in_memory().await?;
 
     conn.call(|conn| {
@@ -91,36 +100,89 @@ async fn close_failure_test() -> Result<(), rusqlite::Error> {
             [],
         )
     })
-    .await
-    .unwrap();
+    .await?;
 
     conn.call(|conn| {
         // Leak a prepared statement to make the database uncloseable
         // See https://www.sqlite.org/c3ref/close.html for details regarding this behaviour
         let stmt = Box::new(conn.prepare("INSERT INTO person VALUES (1, ?1);").unwrap());
         Box::leak(stmt);
+        Ok(())
     })
-    .await;
+    .await?;
 
-    assert_eq!(
-        Error::SqliteFailure(
-            ffi::Error {
-                code: ErrorCode::DatabaseBusy,
-                extended_code: 5
-            },
-            Some("unable to close due to unfinalized statements or unfinished backups".to_string())
-        ),
-        conn.close().await.unwrap_err().1
-    );
+    assert!(match conn.close().await.unwrap_err() {
+        crate::Error::Close((_, e)) => {
+            e == rusqlite::Error::SqliteFailure(
+                ffi::Error {
+                    code: ErrorCode::DatabaseBusy,
+                    extended_code: 5,
+                },
+                Some(
+                    "unable to close due to unfinalized statements or unfinished backups"
+                        .to_string(),
+                ),
+            )
+        }
+        _ => false,
+    });
 
     Ok(())
 }
 
 #[tokio::test]
-async fn debug_format_test() -> Result<(), rusqlite::Error> {
+async fn debug_format_test() -> Result<()> {
     let conn = Connection::open_in_memory().await?;
 
     assert_eq!("Connection".to_string(), format!("{:?}", conn));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_error_display() -> Result<()> {
+    let conn = Connection::open_in_memory().await?;
+
+    let error = crate::Error::Close((conn, rusqlite::Error::InvalidQuery));
+    assert_eq!(
+        "Close((Connection, \"Query is not read-only\"))",
+        format!("{}", error)
+    );
+
+    let error = crate::Error::ConnectionClosed;
+    assert_eq!("ConnectionClosed", format!("{}", error));
+
+    let error = crate::Error::Rusqlite(rusqlite::Error::InvalidQuery);
+    assert_eq!("Rusqlite(\"Query is not read-only\")", format!("{}", error));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_error_source() -> Result<()> {
+    let conn = Connection::open_in_memory().await?;
+
+    let error = crate::Error::Close((conn, rusqlite::Error::InvalidQuery));
+    assert_eq!(
+        std::error::Error::source(&error)
+            .and_then(|e| e.downcast_ref::<rusqlite::Error>())
+            .unwrap(),
+        &rusqlite::Error::InvalidQuery,
+    );
+
+    let error = crate::Error::ConnectionClosed;
+    assert_eq!(
+        std::error::Error::source(&error).and_then(|e| e.downcast_ref::<rusqlite::Error>()),
+        None,
+    );
+
+    let error = crate::Error::Rusqlite(rusqlite::Error::InvalidQuery);
+    assert_eq!(
+        std::error::Error::source(&error)
+            .and_then(|e| e.downcast_ref::<rusqlite::Error>())
+            .unwrap(),
+        &rusqlite::Error::InvalidQuery,
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Implement a breaking API change to make all the methods in this crate return a new `crate::Error` type.