### PR TITLE
Version 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 # Unreleased
 
+None.
+
+# 0.4.0 (3. April 2023)
+
 - **added:** Added `Connection::close` method.
 - **added:** Added `tokio_rusqlite::Error` type.
 - **breaking:** All `Connection` methods now return `Result<_, tokio_rusqlite::Error>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rusqlite"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Programatik <programatik29@gmail.com>"]
 edition = "2021"
 description = "Asynchronous handle for rusqlite library."


### PR DESCRIPTION
- **added:** Added `Connection::close` method.
- **added:** Added `tokio_rusqlite::Error` type.
- **breaking:** All `Connection` methods now return `Result<_, tokio_rusqlite::Error>`.
- **updated:** To latest [rusqlite] version(`0.29`).
