### PR TITLE
chore: add `params!` macro export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@ use std::{
 };
 use tokio::sync::oneshot::{self};
 
+// public exports
+pub use rusqlite::params;
+
 const BUG_TEXT: &str = "bug in tokio-rusqlite, please report";
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #25 

This PR exports the `params!` macro which is very helpful when you have more than 16 parameters