### PR TITLE
Implement `tokio_rusqlite::Connection: From<rusqlite::Connection>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,11 @@ pub struct Connection {
 }
 
 impl Connection {
+    /// Convert an existing `rusqlite::Connection` into a `Connection`.
+    pub async fn from(conn: rusqlite::Connection) -> Self {
+        start(move || Ok(conn)).await.expect(BUG_TEXT)
+    }
+
     /// Open a new connection to a SQLite database.
     ///
     /// `Connection::open(path)` is equivalent to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,11 +174,6 @@ pub struct Connection {
 }
 
 impl Connection {
-    /// Convert an existing `rusqlite::Connection` into a `Connection`.
-    pub async fn from(conn: rusqlite::Connection) -> Self {
-        start(move || Ok(conn)).await.expect(BUG_TEXT)
-    }
-
     /// Open a new connection to a SQLite database.
     ///
     /// `Connection::open(path)` is equivalent to


### PR DESCRIPTION
Allow converting an existing `rusqlite::Connection` into a `tokio_rusqlite::Connection`.

## Why?

I'm using [Refinery](https://docs.rs/refinery) which doesn't support `tokio_rusqlite` but it does support `rusqlite`. So I would like to:
 - Construct a `rusqlite::Connection`
 - Run migrations with Refinery
 - `tokio_rusqlite::Connection::from(...)` to convert the connection to be async for the rest of my apps lifetime.