### PR TITLE
Allow rusqlite bundling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "MIT"
 keywords = ["async", "rusqlite", "sqlite"]
 categories = ["asynchronous", "database"]
 
+[features]
+bundled = ["rusqlite/bundled"]
+
 [dependencies]
 crossbeam-channel = "0.5"
 rusqlite = "0.31"


### PR DESCRIPTION
This adds a `bundled` feature to tokio-rusqlite that just enables the `bundled` feature in rusqlite.