### PR TITLE
Version 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 # Unreleased
 
+Nothing.
+
+# 0.6.0 (20 Sep 2024)
+
 - **updated**: [rusqlite] version to `0.32`.
 - **added**: `bundled` feature corresponding to `rusqlite/bundled` feature.
 - **added**: Implement `From<rusqlite::Connection>` for `Connection`.
+- **removed**: async `Connection::from` implementation instead added above.
 
 # 0.5.1 (13 Feb 2024)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rusqlite"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Programatik <programatik29@gmail.com>", "Adi Salimgereev <adisalimgereev@gmail.com>"]
 edition = "2021"
 description = "Asynchronous handle for rusqlite library."


### PR DESCRIPTION
- **updated**: [rusqlite] version to `0.32`.
- **added**: `bundled` feature corresponding to `rusqlite/bundled` feature.
- **added**: Implement `From<rusqlite::Connection>` for `Connection`.
- **removed**: async `Connection::from` implementation instead added above.