### PR TITLE
Improve error handling ergonomics for call

### DIFF
--- a/examples/multiple_tasks.rs
+++ b/examples/multiple_tasks.rs
@@ -75,7 +75,6 @@ fn add_steven_task(conn: Connection) -> JoinHandle<()> {
                 "INSERT INTO person (name, data) VALUES (?1, ?2)",
                 params![steven.name, steven.data],
             )
-            .map_err(|e| e.into())
         })
         .await
         .unwrap();
@@ -95,7 +94,6 @@ fn add_bob_task(conn: Connection) -> JoinHandle<()> {
                 "INSERT INTO person (name, data) VALUES (?1, ?2)",
                 params![bob.name, bob.data],
             )
-            .map_err(|e| e.into())
         })
         .await
         .unwrap();


### PR DESCRIPTION
This change I think it improves the ergonomics of handling custom errors significantly.

From the tests you can see that it's fairly unintrusive overall, it eliminates the need for lots of `.map_err(|e| e.into())`s and eliminates the need for downcasting the `Error::Other` variant, as well as consolidating `Error::Rusqlite` and `Error::Other` into `Error::Error` which is generic.

In particular look at `test_ergonomic_errors` to see how it improves error ergonomics.

I understand if it's too big of a change though.